### PR TITLE
/を含むリンクが壊れていた

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -67,7 +67,7 @@ const App = (
             : { project: scrapbox.Project.name, title: scrapbox.Page.title };
         // [/project]の形のリンクは何もしない
         if (project === "") return;
-        const titleLc = toLc(decodeURI(title ?? ""));
+        const titleLc = toLc(decodeURIComponent(title ?? ""));
         cache(project, titleLc);
 
         // delay以内にカーソルが離れるかクリックしたら何もしない

--- a/hooks/useBubbles.ts
+++ b/hooks/useBubbles.ts
@@ -170,6 +170,7 @@ export function useBubbles(
   return { cards, cache, show, hide };
 }
 
+/** 同一ページか判定するためのIDを作る */
 function toId(project: string, titleLc: string) {
   return `/${project}/${titleLc}`;
 }

--- a/hooks/useBubbles.ts
+++ b/hooks/useBubbles.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "../deps/preact.tsx";
-import { toLc } from "../utils.ts";
+import { encodeTitle, toLc } from "../utils.ts";
 import type { LinkType, ScrollTo } from "../types.ts";
 import { Page, Scrapbox } from "../deps/scrapbox.ts";
 declare const scrapbox: Scrapbox;
@@ -173,11 +173,14 @@ export function useBubbles(
 function toId(project: string, titleLc: string) {
   return `/${project}/${titleLc}`;
 }
+
 async function fetchPage(
   project: string,
-  titleLc: string,
+  title: string,
 ): Promise<Cache | undefined> {
-  const res = await fetch(`/api/pages/${project}/${titleLc}?followRename=true`);
+  const res = await fetch(
+    `/api/pages/${project}/${encodeTitle(title)}?followRename=true`,
+  );
   const checked = new Date().getTime() / 1000;
   // 存在しないページの時
   if (!res.ok) return;
@@ -185,11 +188,12 @@ async function fetchPage(
 
   // 逆リンクを取得する
   const linksLc = links.map((link) => toLc(link));
+  const titleLc = toLc(title);
   const pages = links1hop.flatMap(({
     title,
     descriptions,
     image,
-  }) => !linksLc.includes(toLc(title)) ? [{ title, descriptions, image }] : []);
+  }) => !linksLc.includes(titleLc) ? [{ title, descriptions, image }] : []);
   return {
     project,
     titleLc,

--- a/hooks/useBubbles.ts
+++ b/hooks/useBubbles.ts
@@ -189,15 +189,14 @@ async function fetchPage(
 
   // 逆リンクを取得する
   const linksLc = links.map((link) => toLc(link));
-  const titleLc = toLc(title);
   const pages = links1hop.flatMap(({
     title,
     descriptions,
     image,
-  }) => !linksLc.includes(titleLc) ? [{ title, descriptions, image }] : []);
+  }) => !linksLc.includes(toLc(title)) ? [{ title, descriptions, image }] : []);
   return {
     project,
-    titleLc,
+    titleLc: toLc(title),
     checked,
     loading: false,
     lines: lines.slice(1), // titleを除く


### PR DESCRIPTION
close [⬜/を含むリンク先にスクロールできない](https://scrapbox.io/takker/⬜%2Fを含むリンク先にスクロールできない)