### PR TITLE
:recycle: api/projects/:projectを叩く箇所を切り出した

### DIFF
--- a/useProject.ts
+++ b/useProject.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "./deps/preact.tsx";
+import { getProject, Result } from "./deps/scrapbox-std.ts";
+import { fetch } from "./cache.ts";
+import { makeEmitter } from "./eventEmitter.ts";
+import {
+  MemberProject,
+  NotFoundError,
+  NotLoggedInError,
+  NotMemberError,
+  NotMemberProject,
+} from "./deps/scrapbox.ts";
+
+type ProjectResult = Result<
+  | NotMemberProject
+  | MemberProject,
+  | NotFoundError
+  | NotLoggedInError
+  | NotMemberError
+>;
+type State<T> = { loading: true } | { loading: false; value: T };
+const emitter = makeEmitter<string, ProjectResult>();
+
+const projectMap = new Map<string, State<ProjectResult>>();
+
+/** /api/projects/:projectの結果を返すhook
+ *
+ * @param project 情報を取得したいprojectの名前
+ * @return projectの情報。未初期化もしくは読み込み中のときは`undefined`を返す
+ */
+export const useProject = (project: string): ProjectResult | undefined => {
+  const [projectResult, setProjectResult] = useState<ProjectResult>();
+
+  useEffect(() => {
+    const state = projectMap.get(project);
+
+    if (state) {
+      setProjectResult(state.loading ? undefined : state.value);
+      emitter.on(project, setProjectResult);
+    } else {
+      projectMap.set(project, { loading: true });
+      emitter.on(project, setProjectResult);
+      setProjectResult(undefined);
+
+      // projectの情報を取得する
+      (async () => {
+        try {
+          const res = await getProject(project, { fetch: (req) => fetch(req) });
+          projectMap.set(project, { loading: false, value: res });
+          emitter.dispatch(project, res);
+        } catch (e: unknown) {
+          // 想定外のエラーはログに出す
+          console.error(e);
+        }
+      })();
+    }
+
+    return () => emitter.off(project, setProjectResult);
+  }, [project]);
+
+  return projectResult;
+};

--- a/useTheme.ts
+++ b/useTheme.ts
@@ -1,52 +1,22 @@
 import { useEffect, useState } from "./deps/preact.tsx";
-import { getProject } from "./deps/scrapbox-std.ts";
-import { fetch } from "./cache.ts";
-import { makeEmitter } from "./eventEmitter.ts";
+import { useProject } from "./useProject.ts";
 import { isTheme, Theme } from "./deps/scrapbox.ts";
 
 const defaultTheme = "default-light";
-const emitter = makeEmitter<string, Theme>();
 
-const themeMap = new Map<string, Theme>();
-
+/** projectのthemeを取得するhook */
 export const useTheme = (project: string): Theme => {
   const [theme, setTheme] = useState<Theme>(defaultTheme);
+  const res = useProject(project);
 
   useEffect(() => {
-    const theme = themeMap.get(project);
-
-    // 対応するthemeが登録されていないときを未初期化状態とみなす
-    if (theme) {
-      setTheme(theme);
-      emitter.on(project, setTheme);
-    } else {
-      // 一旦default themeにしてから、projectのtheme情報を取得する
-      // 何かしらのthemeを設定しておくことで、fetchが実行されていることを示す
-      themeMap.set(project, defaultTheme);
-      emitter.on(project, setTheme);
-      emitter.dispatch(project, defaultTheme);
-
-      // projectのtheme情報を取得する
-      (async () => {
-        try {
-          const res = await getProject(project, { fetch: (req) => fetch(req) });
-          // project情報を取得できなかったときはdefaultのままにする
-          if (!res.ok) return;
-
-          const theme = isTheme(res.value.theme)
-            ? res.value.theme
-            : defaultTheme;
-          themeMap.set(project, theme);
-          emitter.dispatch(project, theme);
-        } catch (e: unknown) {
-          // 想定外のエラーはログに出す
-          console.error(e);
-        }
-      })();
+    if (!res || !res.ok) {
+      setTheme(defaultTheme);
+      return;
     }
-
-    return () => emitter.off(project, setTheme);
-  }, [project]);
+    const theme = res.value.theme;
+    setTheme(isTheme(theme) ? theme : defaultTheme);
+  }, [res]);
 
   return theme;
 };


### PR DESCRIPTION
see [✅ProjectのThemeをpropsバケツリレーせず各要素でhooksから取得する](https://scrapbox.io/takker/✅ProjectのThemeをpropsバケツリレーせず各要素でhooksから取得する#62908d6c1280f0000078b2af)