### PR TITLE
:sparkles: 関連ページリストを更新日時の新しい順に並べる

### DIFF
--- a/Bubble.tsx
+++ b/Bubble.tsx
@@ -119,6 +119,7 @@ export const Bubble = ({
         externalLinked={externalLinked}
         onClick={handleClick}
         source={source}
+        projectsForSort={projects}
         {...props}
       />
     </>


### PR DESCRIPTION
close [⬜関連ページリストを更新日時順に並び替える (takker99/ScrapBubble)](https://scrapbox.io/takker/⬜関連ページリストを更新日時順に並び替える_(takker99%2FScrapBubble))