### PR TITLE
:bug: 空リンクの判定条件を間違えていた

### DIFF
--- a/storage.ts
+++ b/storage.ts
@@ -58,9 +58,9 @@ export const isEmptyLink = (
     linked += (bubble.linked?.length ?? 0) +
       (bubble.projectLinked?.length ?? 0);
     // 2つ以上のページから参照されているなら空リンクでない
-    if (linked > 1) return true;
+    if (linked > 1) return false;
   }
-  return linked > 1;
+  return linked < 2;
 };
 
 /** bubbleを更新する


### PR DESCRIPTION
close [⬜空リンク判定処理がバグっている (takker99/ScrapBubble)](https://scrapbox.io/takker/⬜空リンク判定処理がバグっている_(takker99%2FScrapBubble))