### PR TITLE
:zap: cacheの同時読み込み制限をなくし、代わりにfetchの同時読み込み数を3に制限した

### DIFF
--- a/throttle.test.ts
+++ b/throttle.test.ts
@@ -1,0 +1,57 @@
+import { makeThrottle } from "./throttle.ts";
+import { assertEquals } from "./deps/testing.ts";
+
+Deno.test("makeThrottle()", async (t) => {
+  await t.step("順番に実行", async () => {
+    const throttle = makeThrottle<void>(3);
+
+    const queue: number[] = [];
+    await Promise.all([...Array(10).keys()].map((_, i) =>
+      throttle(() => {
+        queue.push(i);
+        return Promise.resolve();
+      })
+    ));
+
+    assertEquals(queue, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  await t.step("一部を止める", async () => {
+    const throttle = makeThrottle<void>(3);
+
+    const queue: number[] = [];
+    const promises: Promise<unknown>[] = [];
+    const push = (i: number) => {
+      promises.push(
+        throttle(() => {
+          queue.push(i);
+          return Promise.resolve();
+        }),
+      );
+    };
+
+    let resolve: (() => void) | undefined;
+    await Promise.all([
+      push(0),
+      push(1),
+      throttle(() =>
+        new Promise<void>((r) => resolve = r).then(() => {
+          queue.push(2);
+        })
+      ),
+      push(3),
+      push(4),
+      push(5),
+      push(6),
+      throttle(() => {
+        resolve?.();
+        queue.push(7);
+        return Promise.resolve();
+      }),
+      push(8),
+      push(9),
+    ]);
+
+    assertEquals(queue, [0, 1, 3, 4, 5, 6, 7, 8, 2, 9]);
+  });
+});

--- a/throttle.ts
+++ b/throttle.ts
@@ -1,0 +1,38 @@
+export type Fn<T> = () => Promise<T>;
+
+/** 同時に一定数だけPromiseを走らせる函数
+ *
+ * @param max 同時に動かすPromiseの最大数
+ * @return jobを動かして結果を返す函数
+ */
+export const makeThrottle = <T>(max: number): (job: Fn<T>) => Promise<T> => {
+  const queue: [
+    Fn<T>,
+    (value: T) => void,
+    (error: unknown) => void,
+  ][] = [];
+  const pendings = new Set<Promise<unknown>>();
+
+  const runNext = (prev: Promise<unknown>) => {
+    pendings.delete(prev);
+    const task = queue.shift();
+    if (!task) return;
+    const promise = task[0]()
+      .then((result) => task[1](result))
+      .catch((error) => task[2](error));
+    pendings.add(promise);
+    promise.finally(() => runNext(promise));
+  };
+
+  return (job) => {
+    if (pendings.size < max) {
+      const promise = job();
+      pendings.add(promise);
+      promise.finally(() => runNext(promise));
+      return promise;
+    }
+    return new Promise((resolve, reject) => {
+      queue.push([job, resolve, reject]);
+    });
+  };
+};


### PR DESCRIPTION
close [⬜cache読み込みの制限を外してfetch読み込みを制限する (takker99/ScrapBubble)](https://scrapbox.io/takker/⬜cache読み込みの制限を外してfetch読み込みを制限する_(takker99%2FScrapBubble))