### PR TITLE
:+1: ソースコードごとにdebug出力を切り替えられるようにした

### DIFF
--- a/bubble.ts
+++ b/bubble.ts
@@ -4,9 +4,11 @@ import { Listener, makeEmitter } from "./eventEmitter.ts";
 import { Bubble, BubbleStorage, update } from "./storage.ts";
 import { convert } from "./convert.ts";
 import { makeThrottle } from "./throttle.ts";
-import { logger } from "./debug.ts";
+import { createDebug } from "./debug.ts";
 import { getPage } from "./deps/scrapbox-std.ts";
 import { ProjectId, UnixTime } from "./deps/scrapbox.ts";
+
+const logger = createDebug("ScrapBubble:bubble.ts");
 
 const storage: BubbleStorage = new Map();
 /** データを更新中のページのリスト */
@@ -84,7 +86,8 @@ const updateApiCache = async (
   loadingIds.add(id);
   const i = counter++;
 
-  logger.time(`[${i}] Check update ${id}`);
+  const timeTag = `[${i}] Check update ${id}`;
+  logger.time(timeTag);
   try {
     const req = getPage.toRequest(project, title, {
       followRename: true,
@@ -120,7 +123,7 @@ const updateApiCache = async (
     }
 
     const res = await throttle(() => fetch(req));
-    logger.debug(`%c[${i}]Fetch`, "color: gray;", id);
+    logger.debug(`[${i}]Fetch ${id}`);
     const result = await getPage.fromResponse(res.clone());
     await putCache(pureURL, res);
 
@@ -141,7 +144,7 @@ const updateApiCache = async (
   } finally {
     // ロック解除
     loadingIds.delete(id);
-    logger.timeEnd(`[${i}] Check update ${id}`);
+    logger.timeEnd(timeTag);
     counter--;
   }
 };

--- a/mod.tsx
+++ b/mod.tsx
@@ -15,7 +15,7 @@ export type { AppProps };
 export interface MountInit
   extends Partial<Omit<AppProps, "whiteList" | "watchList">> {
   /** debug用有効化フラグ */
-  debug?: boolean;
+  debug?: boolean | Iterable<string>;
 
   /** 透過的に扱うprojectのリスト */
   whiteList?: Iterable<string>;

--- a/useBubbleData.ts
+++ b/useBubbleData.ts
@@ -1,8 +1,10 @@
 import { useLayoutEffect, useState } from "./deps/preact.tsx";
 import { load, subscribe, unsubscribe } from "./bubble.ts";
-import { logger } from "./debug.ts";
+import { createDebug } from "./debug.ts";
 import { ID } from "./id.ts";
 import { Bubble } from "./storage.ts";
+
+const logger = createDebug("ScrapBubble:useBubbleData.ts");
 
 /** bubbleデータを取得するhooks
  *
@@ -27,10 +29,7 @@ export const useBubbleData = (
       // 少し待ってからまとめて更新する
       clearTimeout(timer);
       timer = setTimeout(() => {
-        logger.debug(
-          `%cUpdate ${pageIds.length} pages`,
-          "color: gray;",
-        );
+        logger.debug(`Update ${pageIds.length} pages`);
         setBubbles(
           [...load(pageIds)].flatMap((bubble) => bubble ? [bubble] : []),
         );


### PR DESCRIPTION
close [⬜debug出力にファイル名を入れる (takker99/ScrapBubble)](https://scrapbox.io/takker/⬜debug出力にファイル名を入れる_(takker99%2FScrapBubble))