### PR TITLE
:bug: 関連ページリストの表示上限を超えているページをhoverするとカードがちらついてしまうのを直した

### DIFF
--- a/Card.tsx
+++ b/Card.tsx
@@ -27,7 +27,7 @@ export interface CardProps {
   title: string;
   descriptions: string[];
   thumbnail: string;
-  linkTo: {
+  linkTo?: {
     project?: string;
     titleLc: string;
   };
@@ -71,16 +71,19 @@ export const Card = ({
         position: calcBubblePosition(a),
       });
     },
-    [project, title, delay, linkTo.project, linkTo.titleLc],
+    [project, title, delay, linkTo?.project, linkTo?.titleLc],
   );
 
-  const handleClick = useCallback(() => {
-    pushPageTransition({
-      type: "page",
-      from: { project: linkTo.project ?? project, title: linkTo.titleLc },
-      to: { project, title },
-    });
-  }, [project, title, linkTo.project, linkTo.titleLc]);
+  const handleClick = useMemo(() =>
+    linkTo
+      ? () => {
+        pushPageTransition({
+          type: "page",
+          from: { project: linkTo.project ?? project, title: linkTo.titleLc },
+          to: { project, title },
+        });
+      }
+      : () => {}, [project, title, linkTo?.project, linkTo?.titleLc]);
 
   return (
     <a

--- a/CardList.tsx
+++ b/CardList.tsx
@@ -35,16 +35,6 @@ export const CardList = ({
     externalLinked,
   ]);
   const cards = useBubbleData(ids);
-  const cardsForRender = useMemo(
-    () =>
-      cards.map((card) => {
-        const key = toId(card.project, card.titleLc);
-        const linkTo = linked.get(key) ?? externalLinked.get(key);
-        if (!linkTo) throw Error(`Could not found "linkTo" of ${key}`);
-        return { key, linkTo, ...card };
-      }),
-    [cards, linked, externalLinked],
-  );
 
   const projectsForSort = useMemo(() => [...projectsForSort_], [
     projectsForSort_,
@@ -65,9 +55,9 @@ export const CardList = ({
         return aIndex - bIndex;
       };
 
-      return [...cardsForRender].sort(compare);
+      return [...cards].sort(compare);
     },
-    [cardsForRender, projectsForSort],
+    [cards, projectsForSort],
   );
 
   const cardStyle = useMemo(() => ({
@@ -91,19 +81,31 @@ export const CardList = ({
       onClick={props.onClick}
     >
       {sortedCards.map((
-        { key, project, lines: [{ text: title }], descriptions, image, linkTo },
-      ) => (
-        <li key={key}>
-          <Card
-            project={project}
-            title={title}
-            linkTo={linkTo}
-            descriptions={descriptions}
-            thumbnail={image ?? ""}
-            {...props}
-          />
-        </li>
-      ))}
+        {
+          project,
+          titleLc,
+          lines: [{ text: title }],
+          descriptions,
+          image,
+        },
+      ) => {
+        const key = toId(project, titleLc);
+        // hookの計算にラグがあり、linkToが見つからない場合がある
+        const linkTo = linked.get(key) ?? externalLinked.get(key);
+
+        return (
+          <li key={key}>
+            <Card
+              project={project}
+              title={title}
+              linkTo={linkTo}
+              descriptions={descriptions}
+              thumbnail={image ?? ""}
+              {...props}
+            />
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/__snapshots__/convert.test.ts.snap
+++ b/__snapshots__/convert.test.ts.snap
@@ -3,13 +3,13 @@ export const snapshot = {};
 snapshot[`convert > one project > 逆・順・双方向・空リンク+中身あり・空headword+複数パス2 hop links 1`] = `
 Map {
   "/takker-dist/a" => {
-      checked: 1672173549,
       descriptions: [
         "[A1],[A2],[A3]",
         "https://scrapbox.io/api/pages/takker-dist/A",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1672173548,
@@ -38,11 +38,11 @@ Map {
       updated: 1672173548,
     },
   "/takker-dist/a1" => {
-      checked: 1672173549,
       descriptions: [
       ],
       exists: false,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 0,
@@ -61,7 +61,6 @@ Map {
       updated: 0,
     },
   "/takker-dist/b" => {
-      checked: 1672173549,
       descriptions: [
         "[B1], [B2], [B3]",
         "[A1]",
@@ -69,6 +68,7 @@ Map {
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: true,
       lines: [
         {
           created: 1672173349,
@@ -116,12 +116,12 @@ Map {
       updated: 1673081924,
     },
   "/takker-dist/b1" => {
-      checked: 1672173549,
       descriptions: [
         "[B]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081852,
@@ -149,11 +149,11 @@ Map {
       updated: 1673081852,
     },
   "/takker-dist/b2" => {
-      checked: 1672173549,
       descriptions: [
       ],
       exists: false,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 0,
@@ -172,11 +172,11 @@ Map {
       updated: 0,
     },
   "/takker-dist/b3" => {
-      checked: 1672173549,
       descriptions: [
       ],
       exists: false,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 0,
@@ -194,7 +194,6 @@ Map {
       updated: 0,
     },
   "/takker-dist/c" => {
-      checked: 1672173549,
       descriptions: [
         "[C1], [C2], [C3]",
         "[A2], [A3]",
@@ -202,6 +201,7 @@ Map {
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081866,
@@ -237,12 +237,12 @@ Map {
       updated: 1673081866,
     },
   "/takker-dist/d" => {
-      checked: 1672173549,
       descriptions: [
         "[B1]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081879,
@@ -264,12 +264,12 @@ Map {
       updated: 1673081879,
     },
   "/takker-dist/e" => {
-      checked: 1672173549,
       descriptions: [
         "[B1], [B2]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081909,
@@ -296,7 +296,6 @@ Map {
 snapshot[`convert > one project > (逆リンク|順リンク|双方向リンク)+2 hop links 1`] = `
 Map {
   "/takker-dist/b" => {
-      checked: 1672173549,
       descriptions: [
         "[B1], [B2], [B3]",
         "[A1]",
@@ -304,6 +303,7 @@ Map {
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081924,
@@ -343,12 +343,12 @@ Map {
       updated: 1673081924,
     },
   "/takker-dist/b1" => {
-      checked: 1672173549,
       descriptions: [
         "[B]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081852,
@@ -379,7 +379,6 @@ Map {
       updated: 1673081852,
     },
   "/takker-dist/c" => {
-      checked: 1672173549,
       descriptions: [
         "[C1], [C2], [C3]",
         "[A2], [A3]",
@@ -387,6 +386,7 @@ Map {
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081866,
@@ -422,12 +422,12 @@ Map {
       updated: 1673081866,
     },
   "/takker-dist/d" => {
-      checked: 1672173549,
       descriptions: [
         "[B1]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081879,
@@ -449,12 +449,12 @@ Map {
       updated: 1673081879,
     },
   "/takker-dist/e" => {
-      checked: 1672173549,
       descriptions: [
         "[B1], [B2]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673081909,
@@ -476,13 +476,13 @@ Map {
       updated: 1673081909,
     },
   "/takker-dist/i" => {
-      checked: 1672173549,
       descriptions: [
         "[B] [B1] [K]",
         "https://scrapbox.io/api/pages/takker-dist/I",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: true,
       lines: [
         {
           created: 1673572279,
@@ -524,12 +524,12 @@ Map {
       updated: 1673572411,
     },
   "/takker-dist/j" => {
-      checked: 1672173549,
       descriptions: [
         "[I] [B1]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673572354,
@@ -551,12 +551,12 @@ Map {
       updated: 1673572354,
     },
   "/takker-dist/k" => {
-      checked: 1672173549,
       descriptions: [
         "[I] [B1]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673572392,
@@ -586,7 +586,6 @@ Map {
 snapshot[`convert > two projects > 逆・順・双方向External links 1`] = `
 Map {
   "/takker-dist/f" => {
-      checked: 1672173548,
       descriptions: [
         "[/takker-dist2/B]",
         "[/takker-dist2/C]",
@@ -595,6 +594,7 @@ Map {
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: true,
       lines: [
         {
           created: 1673336497,
@@ -649,12 +649,12 @@ Map {
       updated: 1673336640,
     },
   "/takker-dist2/a" => {
-      checked: 1672173548,
       descriptions: [
         "[/takker-dist/F]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673336561,
@@ -676,12 +676,12 @@ Map {
       updated: 1673336561,
     },
   "/takker-dist2/b" => {
-      checked: 1672173548,
       descriptions: [
         "[B1] [B2]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673336514,
@@ -703,12 +703,12 @@ Map {
       updated: 1673336514,
     },
   "/takker-dist2/c" => {
-      checked: 1672173548,
       descriptions: [
         "[/takker-dist/F]",
       ],
       exists: true,
       image: null,
+      isLinkedCorrect: false,
       lines: [
         {
           created: 1673336584,

--- a/bubble.ts
+++ b/bubble.ts
@@ -109,6 +109,7 @@ const updateApiCache = async (
         for (const [bubbleId, bubble] of converted) {
           const prev = storage.get(bubbleId);
           const updatedBubble = update(prev, bubble);
+          if (!updatedBubble) continue;
           if (prev === updatedBubble) continue;
           storage.set(bubbleId, updatedBubble);
           emitter.dispatch(bubbleId, bubble);

--- a/convert.test.ts
+++ b/convert.test.ts
@@ -131,7 +131,7 @@ Deno.test("convert", async (t) => {
               "hasBackLinksOrIcons": true,
             },
             "collaborators": [],
-          }, new Date(1672173549000)),
+          }),
         );
       },
     );
@@ -278,7 +278,7 @@ Deno.test("convert", async (t) => {
               "hasBackLinksOrIcons": true,
             },
             "collaborators": [],
-          }, new Date(1672173549000)),
+          }),
         );
       },
     );
@@ -398,7 +398,7 @@ Deno.test("convert", async (t) => {
             "hasBackLinksOrIcons": false,
           },
           "collaborators": [],
-        }, new Date(1672173548000)),
+        }),
       );
     });
   });

--- a/deps/immer.ts
+++ b/deps/immer.ts
@@ -1,0 +1,4 @@
+import { enableMapSet } from "https://esm.sh/immer@9.0.17";
+enableMapSet();
+
+export * from "https://esm.sh/immer@9.0.17";

--- a/hasLink.test.ts
+++ b/hasLink.test.ts
@@ -1,5 +1,6 @@
 import { parse } from "./deps/scrapbox-parser.ts";
 import { hasLink } from "./hasLink.ts";
+import { LinkTo } from "./types.ts";
 import { assertEquals } from "./deps/testing.ts";
 
 Deno.test("hasLink()", async (t) => {
@@ -28,22 +29,25 @@ Deno.test("hasLink()", async (t) => {
   });
 
   const links = [
-    ["こっち", true],
-    ["Scrapbox", true],
+    [{ titleLc: "こっち" }, true],
+    [{ titleLc: "Scrapbox" }, false],
+    [{ titleLc: "scrapbox" }, true],
     [
-      "これはリンクではない",
+      { titleLc: "これはリンクではない" },
       false,
     ],
-    ["HashTag", true],
-    ["大文字aと小文字A", true],
-    ["LINK in_table", true],
-    ["/project/external link", false],
-    [{ project: "project", title: "external link" }, true],
-  ] as [string | { project: string; title: string }, boolean][];
+    [{ titleLc: "HashTag" }, false],
+    [{ titleLc: "hashtag" }, true],
+    [{ titleLc: "大文字aと小文字a" }, true],
+    [{ titleLc: "link_in_table" }, true],
+    [{ titleLc: "/project/external link" }, false],
+    [{ project: "project", titleLc: "external link" }, false],
+    [{ project: "project", titleLc: "external_link" }, true],
+  ] as [LinkTo, boolean][];
   for (const [link, result] of links) {
     await t.step(
       `the text ${result ? "has" : "doesn't have"} ${
-        typeof link === "string" ? link : `/${link.project}/${link.title}`
+        !("project" in link) ? link.titleLc : `/${link.project}/${link.titleLc}`
       }`,
       () => {
         assertEquals(hasLink(link, nodes), result);

--- a/storage.test.ts
+++ b/storage.test.ts
@@ -7,9 +7,8 @@ import {
 } from "./deps/testing.ts";
 
 Deno.test("update()", async (t) => {
-  await t.step("更新日時が違う場合", async (t) => {
+  await t.step("新規作成", () => {
     const next: Bubble = {
-      checked: 1672173549,
       descriptions: [
         "[A1],[A2],[A3]",
         "https://scrapbox.io/api/pages/takker-dist/A",
@@ -42,11 +41,51 @@ Deno.test("update()", async (t) => {
       project: "takker-dist",
       titleLc: "a",
       updated: 1672173550,
+      isLinkedCorrect: false,
+    };
+
+    const updated = update(undefined, next);
+    assertStrictEquals(updated, next);
+  });
+  await t.step("更新日時が違う場合", async (t) => {
+    const next: Bubble = {
+      descriptions: [
+        "[A1],[A2],[A3]",
+        "https://scrapbox.io/api/pages/takker-dist/A",
+      ],
+      exists: true,
+      image: null,
+      lines: [
+        {
+          created: 1672173548,
+          id: "dummy",
+          text: "A",
+          updated: 1672173548,
+          userId: "dummy",
+        },
+        {
+          created: 1672173548,
+          id: "dummy",
+          text: "[A1],[A2],[A3]",
+          updated: 1672173548,
+          userId: "dummy",
+        },
+        {
+          created: 1672173548,
+          id: "dummy",
+          text: "https://scrapbox.io/api/pages/takker-dist/A",
+          updated: 1672173548,
+          userId: "dummy",
+        },
+      ],
+      project: "takker-dist",
+      titleLc: "a",
+      updated: 1672173550,
+      isLinkedCorrect: false,
     };
 
     await t.step("双方ともlinkedなし", () => {
       const prev: Bubble = {
-        checked: 1672173549,
         descriptions: [
           "[A1],[A2],[A3]",
           "https://scrapbox.io/api/pages/takker-dist/A",
@@ -79,6 +118,7 @@ Deno.test("update()", async (t) => {
         project: "takker-dist",
         titleLc: "a",
         updated: 1672173548,
+        isLinkedCorrect: false,
       };
       const updated = update(prev, next);
       assertNotStrictEquals(updated, prev);
@@ -86,13 +126,12 @@ Deno.test("update()", async (t) => {
       assertNotEquals(updated, prev);
       assertEquals(updated, next);
 
-      assertStrictEquals(updated.lines, prev.lines);
-      assertStrictEquals(updated.descriptions, next.descriptions);
+      assertStrictEquals(updated?.lines, prev.lines);
+      assertStrictEquals(updated?.descriptions, next.descriptions);
     });
 
     await t.step("古い方にlinkedあり", () => {
       const prev: Bubble = {
-        checked: 1672173549,
         descriptions: [
           "[A1],[A2],[A3]",
           "https://scrapbox.io/api/pages/takker-dist/A",
@@ -126,6 +165,7 @@ Deno.test("update()", async (t) => {
         project: "takker-dist",
         titleLc: "a",
         updated: 1672173548,
+        isLinkedCorrect: true,
       };
       const updated = update(prev, next);
       assertNotStrictEquals(updated, prev);
@@ -134,14 +174,13 @@ Deno.test("update()", async (t) => {
       assertNotEquals(updated, next);
       assertEquals(updated, { ...next, linked: prev.linked });
 
-      assertStrictEquals(updated.lines, prev.lines);
-      assertStrictEquals(updated.descriptions, next.descriptions);
+      assertStrictEquals(updated?.lines, prev.lines);
+      assertStrictEquals(updated?.descriptions, next.descriptions);
     });
   });
 
   await t.step("更新日時が同じ場合", async (t) => {
     const next: Bubble = {
-      checked: 1672173549,
       descriptions: [
         "[A1],[A2],[A3]",
         "https://scrapbox.io/api/pages/takker-dist/A",
@@ -175,57 +214,11 @@ Deno.test("update()", async (t) => {
       project: "takker-dist",
       titleLc: "a",
       updated: 1672173548,
+      isLinkedCorrect: true,
     };
-
-    await t.step("checkedのみ違う", () => {
-      const prev: Bubble = {
-        checked: 1672173547,
-        descriptions: [
-          "[A1],[A2],[A3]",
-          "https://scrapbox.io/api/pages/takker-dist/A",
-        ],
-        exists: true,
-        image: null,
-        lines: [
-          {
-            created: 1672173548,
-            id: "dummy",
-            text: "A",
-            updated: 1672173548,
-            userId: "dummy",
-          },
-          {
-            created: 1672173548,
-            id: "dummy",
-            text: "[A1],[A2],[A3]",
-            updated: 1672173548,
-            userId: "dummy",
-          },
-          {
-            created: 1672173548,
-            id: "dummy",
-            text: "https://scrapbox.io/api/pages/takker-dist/A",
-            updated: 1672173548,
-            userId: "dummy",
-          },
-        ],
-        linked: ["e2", "e3"],
-        project: "takker-dist",
-        titleLc: "a",
-        updated: 1672173548,
-      };
-      const updated = update(prev, next);
-      assertStrictEquals(updated, prev);
-      assertNotStrictEquals(updated, next);
-
-      assertStrictEquals(updated.checked, next.checked);
-      assertStrictEquals(updated.lines, prev.lines);
-      assertStrictEquals(updated.descriptions, prev.descriptions);
-    });
 
     await t.step("linkedのみ違う", () => {
       const prev: Bubble = {
-        checked: 1672173549,
         descriptions: [
           "[A1],[A2],[A3]",
           "https://scrapbox.io/api/pages/takker-dist/A",
@@ -259,15 +252,16 @@ Deno.test("update()", async (t) => {
         project: "takker-dist",
         titleLc: "a",
         updated: 1672173548,
+        isLinkedCorrect: true,
       };
       const updated = update(prev, next);
       assertNotStrictEquals(updated, prev);
       assertNotStrictEquals(updated, next);
       assertEquals(updated, next);
 
-      assertStrictEquals(updated.lines, prev.lines);
-      assertStrictEquals(updated.descriptions, prev.descriptions);
-      assertStrictEquals(updated.linked, next.linked);
+      assertStrictEquals(updated?.lines, prev.lines);
+      assertStrictEquals(updated?.descriptions, prev.descriptions);
+      assertStrictEquals(updated?.linked, next.linked);
     });
   });
 });

--- a/useBubbleData.ts
+++ b/useBubbleData.ts
@@ -18,8 +18,23 @@ export const useBubbleData = (
   const [bubbles, setBubbles] = useState<readonly Bubble[]>([]);
 
   useLayoutEffect(() => {
+    const update = () => {
+      setBubbles(() => {
+        const bubbles = [...load(pageIds)].flatMap((bubble) =>
+          bubble ? [bubble] : []
+        );
+
+        // debug用
+        logger.debug(
+          `Required: ${pageIds.length} pages, ${bubbles.length} found`,
+          bubbles,
+        );
+        return bubbles;
+      });
+    };
+
     // データの初期化
-    setBubbles([...load(pageIds)].flatMap((bubble) => bubble ? [bubble] : []));
+    update();
 
     // データ更新用listenerの登録
 
@@ -30,16 +45,16 @@ export const useBubbleData = (
       clearTimeout(timer);
       timer = setTimeout(() => {
         logger.debug(`Update ${pageIds.length} pages`);
-        setBubbles(
-          [...load(pageIds)].flatMap((bubble) => bubble ? [bubble] : []),
-        );
+        update();
       }, 10);
     };
 
     // 更新を購読する
     pageIds.forEach((id) => subscribe(id, updateData));
     return () => pageIds.forEach((id) => unsubscribe(id, updateData));
-  }, [pageIds]);
+  }, pageIds);
+
+  // debug用
 
   return bubbles;
 };


### PR DESCRIPTION
close [⬜関連ページリストの表示上限を突破しているページをhoverするとbubblesがちらつく](https://scrapbox.io/takker/⬜関連ページリストの表示上限を突破しているページをhoverするとbubblesがちらつく)