### PR TITLE
fix: `links2hop[].linksLc`に、そのページ内の全てのリンクが含まれるようになった

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -56,8 +56,7 @@ export const convert = (
       const linkLc of card.linksLc.filter((linkLc) => linksLc.includes(linkLc))
     ) {
       const cardId = toId(project, linkLc);
-      const bubble = storage.get(cardId);
-      if (!bubble) throw Error(`storage already must have "${cardId}"`);
+      const bubble = storage.get(cardId) ?? makeDummy(project, linkLc);
       if (!bubble.linked) {
         bubble.linked = [card.titleLc];
         continue;
@@ -99,8 +98,7 @@ export const convert = (
       // 逆リンクを作る
       // 重複はありえないので配列でいい
       const cardId = toId(project, linkLc);
-      const bubble = storage.get(cardId);
-      if (!bubble) throw Error(`storage already must have "${cardId}"`);
+      const bubble = storage.get(cardId) ?? makeDummy(project, linkLc);
       if (!bubble.linked) {
         bubble.linked = [card.titleLc];
         continue;


### PR DESCRIPTION
以前は、親ページに含まれるlinksに限定されていた。

本当は型定義の変更や単体テストの書き換えまでしたいが、時間が無いので後回しにする。