### PR TITLE
fix: `/*@__PURE__*/` is not a project link

### DIFF
--- a/parseLink.test.ts
+++ b/parseLink.test.ts
@@ -62,3 +62,9 @@ Deno.test("internal link", () => {
     title: "title/with#/",
   });
 });
+
+Deno.test("project-like title", () => {
+  assertEquals(parseLink({ pathType: "root", href: "/*@__PURE__*/" }), {
+    title: "/*@__PURE__*/",
+  });
+});

--- a/parseLink.ts
+++ b/parseLink.ts
@@ -15,23 +15,20 @@ export const parseLink = (
   title: string;
   hash?: string;
 } => {
-  if (link.pathType === "root") {
+  root: if (link.pathType === "root") {
     const [, project = "", title = ""] = link.href.match(
       /\/([\w\-]+)(?:\/?|\/(.*))$/,
     ) ?? ["", "", ""];
-    if (project === "") {
-      throw SyntaxError(`Failed to get a project name from "${link.href}"`);
-    }
+    if (project === "") break root;
     const [, hash] = title?.match?.(/#([a-f\d]{24,32})$/) ?? ["", ""];
     return title === ""
       ? { project }
       : hash === ""
       ? { project, title }
       : { project, title: title.slice(0, -1 - hash.length), hash };
-  } else {
-    const [, hash] = link.href.match(/#([a-f\d]{24,32})$/) ?? ["", ""];
-    return hash === ""
-      ? { title: link.href }
-      : { title: link.href.slice(0, -1 - hash.length), hash };
   }
+  const [, hash] = link.href.match(/#([a-f\d]{24,32})$/) ?? ["", ""];
+  return hash === ""
+    ? { title: link.href }
+    : { title: link.href.slice(0, -1 - hash.length), hash };
 };


### PR DESCRIPTION
close [✅️️/で囲まれたリンクがproject linkとみなされてしまう (takker99/ScrapBubble)](https://scrapbox.io/takker/✅️️%2Fで囲まれたリンクがproject_linkとみなされてしまう_(takker99%2FScrapBubble))